### PR TITLE
Remove line break from signature to ease comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,8 +155,7 @@
         <pre><code>Certificate fingerprints:
 MD5:    54:73:70:C6:4B:FE:31:88:ED:18:F5:DF:1E:08:EB:19
 SHA1:   C1:BE:BA:F7:9A:57:74:B7:5B:82:D5:0A:36:60:24:99:00:98:5D:C7
-SHA256: 8E:09:CB:8F:9F:28:DA:DB:A9:32:84:AD:7C:AC:F3:E7 \
-        58:56:54:09:49:31:9D:FD:CB:16:BC:11:09:DE:25:B0</code></pre>
+SHA256: 8E:09:CB:8F:9F:28:DA:DB:A9:32:84:AD:7C:AC:F3:E7:58:56:54:09:49:31:9D:FD:CB:16:BC:11:09:DE:25:B0</code></pre>
       </section>
       <section>
         <h3>Migration from LineageOS</h3>


### PR DESCRIPTION
In my tests `keytool` never outputted such a line break (`\`). Also, it is much easier to copy & paste the hash for comparison if it is not split into two parts (and you manually need to add a `: ` in the middle).