### PR TITLE
Add instructions for devices with FBE

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,11 @@ SHA256: 8E:09:CB:8F:9F:28:DA:DB:A9:32:84:AD:7C:AC:F3:E7 \
         <p>you have to uninstall them before the ROM migration. You
         also have to uninstall the GApps if you have previously
         installed them.</p>
+        <p>Note that if the device is encrypted with FBE things are
+        a bit more difficult: you'll need to extract the script
+        <pre>update-binary</pre> from the migration script zipfile
+        and run it from the current installation via ADB, from root.
+        </p>
         <p>Then, download <a href=
         "https://download.lineage.microg.org/extra">the migration
         ZIP</a> and <a href=


### PR DESCRIPTION
Hello, while trying to migrate keys I would get this error: `ERROR: packages.xml not found. Exiting...` from the recovery.
I found a crude workaround to run the script when the filesystem is decrypted, and this PR documents it.
Maybe it can be documented more precisely from another page and just linked.
Feel free to edit it before merging.