### PR TITLE
Change update-interval to once-a-month

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
         ""></div>
         <div class="content">
           <h3>OTA updates</h3>
-          <p>We ship OTA updates from upstream LineageOS twice a month. In
+          <p>We ship OTA updates from upstream LineageOS once a month. In
           this way you always receive new features and security
           updates just few days after they are released
           mainline.</p>
@@ -119,7 +119,7 @@
       <section class="special">
         <ul class="icons labeled">
           <li><span class="icon fa-refresh"><span class=
-          "label">OTA updates twice a month</span></span></li>
+          "label">OTA updates once a month</span></span></li>
           <li><span class="icon fa-cloud"><span class=
           "label">Compatible with Google Play
           Services</span></span></li>
@@ -386,7 +386,7 @@
       Heck, no! We sign all our builds with our own private
       keys.</p>
       <p id="faq9"><b>Do you offer OTA updates?</b><br>
-      Yes, twice a month.</p>
+      Yes, once a month.</p>
       <p id="faq10"><b>Do you offer delta updates?</b><br>
       Not currently, but it can be done if there's real demand.</p>
       <p id="faq11"><b>Can I install apps from the Play Store on


### PR DESCRIPTION
Since a couple of month the update-interval changed from twice a month to once a month. I think this is because the build-server isn't fast enough anymore to do all the builds for all devices within 2 weeks. Thus, I think it makes sense to communicate this on the official website.